### PR TITLE
Randomized border colour, and sped up calculation time.

### DIFF
--- a/HintsHighlight.asc
+++ b/HintsHighlight.asc
@@ -1,7 +1,7 @@
 /** 
  * @author  Artium Nihamkin, artium@nihamkin.com
  * @date    09/2018
- * @version 1.1
+ * @version 1.2
  *  
  * @brief This is an AGS module that makes it possible to add a hinting
  *        system to a game. Upon user action, a shape will be drawn
@@ -70,7 +70,7 @@
 /** 
   * The color of the highlight shape
   */
-#define BORDER_COLOR Game.GetColorFromRGB(8, 0,  255)
+#define BORDER_COLOR Game.GetColorFromRGB(Random(255), Random(255), Random(255))
 
 /**
  * To prevent highlights that are too small, it is possible to define minimal
@@ -248,9 +248,9 @@ static function HintsHighlighter::CalculateHintsForRoom()
   }
     
   // Precalculate the bounding rectangle of each visible hotspot
-  for(int x = 0; x < System.ScreenWidth; x++)
+  for(int x = Random(1); x < System.ScreenWidth; x+=2)
   {
-    for(int y = 0; y < System.ScreenHeight; y++)
+    for(int y = Random(1); y < System.ScreenHeight; y+=2)
     {
       // Please notice that x,y are screen coordinares
       // We simply ignore hotspots that are not currently visible.
@@ -296,6 +296,8 @@ static function HintsHighlighter::CalculateHintsForRoom()
         
         float h = IntToFloat(hotspotsExtData[i].boundBottom - hotspotsExtData[i].boundTop);
         float w = IntToFloat(hotspotsExtData[i].boundRight  - hotspotsExtData[i].boundLeft);
+		if (h == 0.0) h = 1.0;
+        if (w == 0.0) w = 1.0;
         
         if (h/w > HINT_SHAPE_MIXED_RATIO || w/h > HINT_SHAPE_MIXED_RATIO) {
           DrawRectangle(surface,  i);


### PR DESCRIPTION
I've made the border color random, so it's easier to identify the various squares and circles from each other.  A better solution would be to cycle through a set of predetermined colours, but that might be overthinking it.

I've also sped up the time to calculate everything, by only checking every other pixel for a hotspot. This gets rid of the noticable delay when you click the key that draws everything. The only downside is that there's only a 25% chance of finding a 1x1 pixel hotspot.
I've made the starting location for calculation randomized so there's a chance it can pick up a 1x1 pixel hotspot with enough button presses. But this also comes with the cost of the shapes sometimes moving a little bit on repeated button presses.